### PR TITLE
Invalid Date Birthday crash

### DIFF
--- a/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
@@ -1,9 +1,7 @@
 package com.alexstyl.specialdates.addevent.ui;
 
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import android.transition.TransitionManager;
+import android.support.transition.TransitionManager;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.CheckedTextView;
@@ -14,7 +12,6 @@ import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.date.Date;
 import com.alexstyl.specialdates.date.MonthInt;
 import com.alexstyl.specialdates.upcoming.MonthLabels;
-import com.alexstyl.specialdates.util.Utils;
 import com.novoda.notils.caster.Views;
 
 import java.util.Locale;
@@ -61,19 +58,13 @@ public class BirthdayDatePicker extends LinearLayout {
                 }
             }
 
-            @TargetApi(Build.VERSION_CODES.KITKAT)
             private void hideYearPicker() {
-                if (Utils.hasKitKat()) {
-                    TransitionManager.beginDelayedTransition(BirthdayDatePicker.this);
-                }
+                TransitionManager.beginDelayedTransition(BirthdayDatePicker.this);
                 yearPicker.setVisibility(GONE);
             }
 
-            @TargetApi(Build.VERSION_CODES.KITKAT)
             private void showYearPicker() {
-                if (Utils.hasKitKat()) {
-                    TransitionManager.beginDelayedTransition(BirthdayDatePicker.this);
-                }
+                TransitionManager.beginDelayedTransition(BirthdayDatePicker.this);
                 yearPicker.setVisibility(VISIBLE);
             }
         });

--- a/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
@@ -143,6 +143,7 @@ public class BirthdayDatePicker extends LinearLayout {
     }
 
     @MonthInt
+    @SuppressWarnings("WrongConstant")
     private int getMonth() {
         return monthPicker.getValue();
     }

--- a/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/BirthdayDatePicker.java
@@ -10,6 +10,7 @@ import android.widget.NumberPicker;
 
 import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.date.Date;
+import com.alexstyl.specialdates.date.DateConstants;
 import com.alexstyl.specialdates.date.MonthInt;
 import com.alexstyl.specialdates.upcoming.MonthLabels;
 import com.novoda.notils.caster.Views;
@@ -85,6 +86,7 @@ public class BirthdayDatePicker extends LinearLayout {
         monthPicker.setDisplayedValues(labels.getMonthsOfYear());
 
         monthPicker.setValue(today.getMonth());
+        monthPicker.setOnValueChangedListener(dateValidator);
     }
 
     private void setupYearPicker() {
@@ -92,6 +94,7 @@ public class BirthdayDatePicker extends LinearLayout {
         yearPicker.setMaxValue(todaysYear());
 
         yearPicker.setValue(todaysYear());
+        yearPicker.setOnValueChangedListener(dateValidator);
     }
 
     private Integer todaysYear() {
@@ -142,5 +145,30 @@ public class BirthdayDatePicker extends LinearLayout {
     private int getYear() {
         return yearPicker.getValue();
     }
+
+    private final NumberPicker.OnValueChangeListener dateValidator = new NumberPicker.OnValueChangeListener() {
+        @Override
+        public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
+            if (getMonth() == DateConstants.FEBRUARY && isDisplayingYear()) {
+
+                if (isValidDate(29, DateConstants.FEBRUARY, getYear())) {
+                    dayPicker.setMaxValue(29);
+                } else {
+                    dayPicker.setMaxValue(28);
+                }
+            } else {
+                dayPicker.setMaxValue(31);
+            }
+        }
+
+        private boolean isValidDate(int dayOfMonth, int month, int year) {
+            try {
+                Date.on(dayOfMonth, month, year);
+                return true;
+            } catch (IllegalArgumentException ex) {
+                return false;
+            }
+        }
+    };
 
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/date/Date.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/date/Date.java
@@ -3,6 +3,9 @@ package com.alexstyl.specialdates.date;
 import com.alexstyl.specialdates.Optional;
 import com.alexstyl.specialdates.contact.ShortDate;
 
+import java.util.Locale;
+
+import org.joda.time.IllegalFieldValueException;
 import org.joda.time.LocalDate;
 
 import static com.alexstyl.specialdates.date.DateConstants.DECEMBER;
@@ -38,8 +41,12 @@ public class Date implements ShortDate {
             throw new IllegalArgumentException(
                     "Do not call DayDate.on() if no year is present. Call the respective method without the year argument instead");
         }
-        LocalDate localDate = new LocalDate(year, month, dayOfMonth);
-        return new Date(localDate, new Optional<>(year));
+        try {
+            LocalDate localDate = new LocalDate(year, month, dayOfMonth);
+            return new Date(localDate, new Optional<>(year));
+        } catch (IllegalFieldValueException a) {
+            throw new IllegalArgumentException(String.format(Locale.US, "%d/%d/%d is invalid", dayOfMonth, month, year));
+        }
     }
 
     private Date(LocalDate localDate, Optional<Integer> year) {

--- a/mobile/src/test/java/com/alexstyl/specialdates/events/DateTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/DateTest.java
@@ -117,4 +117,9 @@ public class DateTest {
 
         assertThat(firstDate.equals(secondDate)).isFalse();
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsException_whenInvalidDateIsCreated() {
+        Date.on(31, FEBRUARY, 1991);
+    }
 }

--- a/mobile/src/test/java/com/alexstyl/specialdates/events/DateTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/events/DateTest.java
@@ -104,16 +104,16 @@ public class DateTest {
 
     @Test
     public void whenComparingToSameDate_thenTheyAreEqual() {
-        Date firstDate = Date.on(16, 4, 1991);
-        Date secondDate = Date.on(16, 4, 1991);
+        Date firstDate = Date.on(16, APRIL, 1991);
+        Date secondDate = Date.on(16, APRIL, 1991);
 
         assertThat(firstDate.equals(secondDate)).isTrue();
     }
 
     @Test
     public void whenComparingToDateWithDifferentYear_thenTheyAreNotEqual() {
-        Date firstDate = Date.on(16, 4, 1991);
-        Date secondDate = Date.on(16, 4, 1987);
+        Date firstDate = Date.on(16, APRIL, 1991);
+        Date secondDate = Date.on(16, APRIL, 1987);
 
         assertThat(firstDate.equals(secondDate)).isFalse();
     }


### PR DESCRIPTION
#### Description
This PR fixes the `IllegalFieldValueException` crash thrown when the user tries to create a Birthday on an invalid date. On the Birthday creation screen, when a new month or year is selected, we update the max day of month for the current month.

##### Crashlytics Log

```
Fatal Exception: org.joda.time.IllegalFieldValueException: Value 31 for dayOfMonth must be in the range [1,30]
       at org.joda.time.field.FieldUtils.verifyValueBounds(FieldUtils.java:252)
       at org.joda.time.chrono.BasicChronology.getDateMidnightMillis(BasicChronology.java:632)
       at org.joda.time.chrono.BasicChronology.getDateTimeMillis0(BasicChronology.java:186)
       at org.joda.time.chrono.BasicChronology.getDateTimeMillis(BasicChronology.java:160)
       at org.joda.time.chrono.AssembledChronology.getDateTimeMillis(AssembledChronology.java:120)
       at org.joda.time.LocalDate.(LocalDate.java:457)
       at org.joda.time.LocalDate.(LocalDate.java:436)
       at com.alexstyl.specialdates.date.Date.on(Date.java:41)
       at com.alexstyl.specialdates.addevent.ui.BirthdayDatePicker.getDisplayingBirthday(BirthdayDatePicker.java:131)
       at com.alexstyl.specialdates.addevent.BirthdayPickerDialog$1.onClick(BirthdayPickerDialog.java:93)
       at android.support.v7.app.AlertController$ButtonHandler.handleMessage(AlertController.java:157)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:154)
       at android.app.ActivityThread.main(ActivityThread.java:6077)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
```

##### Tests added 

Yes. The Date class now throws an IllegalArgumentException when some invalid date was asked to be created. Tests were added around this case.