### PR TITLE
Display AdMob ads on the upcoming events list

### DIFF
--- a/common/versions.gradle
+++ b/common/versions.gradle
@@ -1,5 +1,5 @@
 ext {
-    android_support_version = '25.1.0'
+    android_support_version = '25.1.1'
     play_services_version = '10.0.1'
 }
 

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -33,6 +33,7 @@ android {
         versionCode androidVersionCode
         versionName androidVersionName
         manifestPlaceholders = [crashlyticsApiKey: crashlyticsKey]
+        resValue "string", "admob_unit_id", "\"$adMobUnitId\""
     }
 
     buildTypes {
@@ -88,6 +89,9 @@ dependencies {
     }
     compile "com.google.android.gms:play-services-wearable:$play_services_version"
     compile 'com.theartofdev.edmodo:android-image-cropper:2.3.1'
+
+    compile "com.google.firebase:firebase-core:$play_services_version"
+    compile "com.google.firebase:firebase-ads:$play_services_version"
 
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
     debugCompile 'com.facebook.stetho:stetho:1.3.0'

--- a/mobile/src/main/java/com/alexstyl/specialdates/date/Date.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/date/Date.java
@@ -16,6 +16,7 @@ import static com.alexstyl.specialdates.date.DateConstants.*;
  */
 public class Date implements ShortDate {
 
+    public static final Date BEGINNING_OF_TIME = Date.on(1, JANUARY, NO_YEAR);
     private final LocalDate localDate;
     private final Optional<Integer> year;
 

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/AdViewModel.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/AdViewModel.java
@@ -1,6 +1,14 @@
 package com.alexstyl.specialdates.upcoming;
 
+import com.alexstyl.specialdates.date.Date;
+
 final public class AdViewModel implements UpcomingRowViewModel {
+    private final Date afterDate;
+
+    AdViewModel(Date afterDate) {
+        this.afterDate = afterDate;
+    }
+
     @Override
     public int getViewType() {
         return UpcomingRowViewType.AD;
@@ -9,5 +17,25 @@ final public class AdViewModel implements UpcomingRowViewModel {
     @Override
     public long getId() {
         return 1337;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AdViewModel that = (AdViewModel) o;
+
+        return afterDate.equals(that.afterDate);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return afterDate.hashCode();
     }
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/AdViewModel.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/AdViewModel.java
@@ -1,0 +1,13 @@
+package com.alexstyl.specialdates.upcoming;
+
+final public class AdViewModel implements UpcomingRowViewModel {
+    @Override
+    public int getViewType() {
+        return UpcomingRowViewType.AD;
+    }
+
+    @Override
+    public long getId() {
+        return 1337;
+    }
+}

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsAdRules.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsAdRules.java
@@ -1,0 +1,11 @@
+package com.alexstyl.specialdates.upcoming;
+
+interface UpcomingEventsAdRules {
+    boolean shouldAppendAdForEndOfMonth(int index);
+
+    void onNewMonthAdded(int index);
+
+    boolean shouldAppendAdAt(int index);
+
+    void onNewAdAdded(int index);
+}

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFreeUserAdRules.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFreeUserAdRules.java
@@ -1,0 +1,30 @@
+package com.alexstyl.specialdates.upcoming;
+
+final class UpcomingEventsFreeUserAdRules implements UpcomingEventsAdRules {
+
+    private int lastAdIndex = 0;
+    private boolean monthHandled = false;
+    private int DAY_INTERVAL = 2;
+
+    @Override
+    public boolean shouldAppendAdForEndOfMonth(int index) {
+        return index - lastAdIndex >= DAY_INTERVAL;
+    }
+
+    @Override
+    public void onNewMonthAdded(int index) {
+        monthHandled = false;
+        lastAdIndex = index;
+    }
+
+    @Override
+    public boolean shouldAppendAdAt(int index) {
+        return !monthHandled && index - lastAdIndex >= DAY_INTERVAL;
+    }
+
+    @Override
+    public void onNewAdAdded(int index) {
+        monthHandled = true;
+        lastAdIndex = index;
+    }
+}

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsLoader.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsLoader.java
@@ -88,7 +88,11 @@ class UpcomingEventsLoader extends SimpleAsyncTaskLoader<List<UpcomingRowViewMod
                 new NamedaysViewModelFactory(today),
                 MonthLabels.forLocale(Locale.getDefault())
         );
-        UpcomingRowViewModelsBuilder upcomingRowViewModelsBuilder = new UpcomingRowViewModelsBuilder(period, upcomingRowViewModelFactory)
+        UpcomingRowViewModelsBuilder upcomingRowViewModelsBuilder = new UpcomingRowViewModelsBuilder(
+                period,
+                upcomingRowViewModelFactory,
+                new UpcomingEventsFreeUserAdRules()
+        )
                 .withContactEvents(contactEvents);
 
         if (shouldLoadBankHolidays()) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
@@ -71,16 +71,17 @@ final class UpcomingRowViewModelsBuilder {
         while (dateComparator.compare(indexDate, lastDate) <= 0) {
             AnnualDate annualDate = new AnnualDate(indexDate);
             if (containsAnyEventsOn(annualDate)) {
-                if (indexDate.getYear() != previousDate.getYear()) {
-                    rowsViewModels.add(upcomingRowViewModelFactory.createRowForYear(indexDate.getYear()));
-                }
                 if (indexDate.getMonth() != previousDate.getMonth()) {
                     if (adRules.shouldAppendAdForEndOfMonth(index)) {
                         rowsViewModels.add(new AdViewModel(indexDate));
                     }
+                    if (indexDate.getYear() != previousDate.getYear()) {
+                        rowsViewModels.add(upcomingRowViewModelFactory.createRowForYear(indexDate.getYear()));
+                    }
                     rowsViewModels.add(upcomingRowViewModelFactory.createRowForMonth(indexDate.getMonth()));
                     adRules.onNewMonthAdded(index);
                 }
+
                 if (adRules.shouldAppendAdAt(index)) {
                     rowsViewModels.add(new AdViewModel(indexDate));
                     adRules.onNewAdAdded(index);

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
@@ -17,17 +17,19 @@ final class UpcomingRowViewModelsBuilder {
 
     private static final List<UpcomingRowViewModel> NO_CELEBRATIONS = Collections.emptyList();
     private static final List<ContactEvent> NO_CONTACT_EVENTS = Collections.emptyList();
-    private static final DateComparator COMPARATOR = DateComparator.INSTANCE;
+    private final DateComparator dateComparator = DateComparator.INSTANCE;
 
     private final HashMapList<AnnualDate, ContactEvent> contactEvents = new HashMapList<>();
     private final HashMap<AnnualDate, NamesInADate> namedays = new HashMap<>();
     private final HashMap<AnnualDate, BankHoliday> bankHolidays = new HashMap<>();
     private final TimePeriod duration;
     private final UpcomingEventRowViewModelFactory upcomingRowViewModelFactory;
+    private final UpcomingEventsAdRules adRules;
 
-    UpcomingRowViewModelsBuilder(TimePeriod duration, UpcomingEventRowViewModelFactory upcomingRowViewModelFactory) {
+    UpcomingRowViewModelsBuilder(TimePeriod duration, UpcomingEventRowViewModelFactory upcomingRowViewModelFactory, UpcomingEventsAdRules adRules) {
         this.duration = duration;
         this.upcomingRowViewModelFactory = upcomingRowViewModelFactory;
+        this.adRules = adRules;
     }
 
     UpcomingRowViewModelsBuilder withContactEvents(List<ContactEvent> contactEvents) {
@@ -64,14 +66,24 @@ final class UpcomingRowViewModelsBuilder {
         Date lastDate = duration.getEndingDate();
 
         Date previousDate = Date.startOfTheYear(indexDate.getYear());
-        while (COMPARATOR.compare(indexDate, lastDate) <= 0) {
+
+        int index = 0;
+        while (dateComparator.compare(indexDate, lastDate) <= 0) {
             AnnualDate annualDate = new AnnualDate(indexDate);
             if (containsAnyEventsOn(annualDate)) {
                 if (indexDate.getYear() != previousDate.getYear()) {
                     rowsViewModels.add(upcomingRowViewModelFactory.createRowForYear(indexDate.getYear()));
                 }
                 if (indexDate.getMonth() != previousDate.getMonth()) {
+                    if (adRules.shouldAppendAdForEndOfMonth(index)) {
+                        rowsViewModels.add(new AdViewModel(indexDate));
+                    }
                     rowsViewModels.add(upcomingRowViewModelFactory.createRowForMonth(indexDate.getMonth()));
+                    adRules.onNewMonthAdded(index);
+                }
+                if (adRules.shouldAppendAdAt(index)) {
+                    rowsViewModels.add(new AdViewModel(indexDate));
+                    adRules.onNewAdAdded(index);
                 }
                 UpcomingRowViewModel viewModel = upcomingRowViewModelFactory.createEventViewModel(
                         indexDate,
@@ -81,11 +93,8 @@ final class UpcomingRowViewModelsBuilder {
                 );
                 rowsViewModels.add(viewModel);
                 previousDate = indexDate;
-                if (rowsViewModels.size() % 2 == 0) {
-                    rowsViewModels.add(new AdViewModel());
-                }
+                index++;
             }
-
             indexDate = indexDate.addDay(1);
         }
         return rowsViewModels;

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewModelsBuilder.java
@@ -81,6 +81,9 @@ final class UpcomingRowViewModelsBuilder {
                 );
                 rowsViewModels.add(viewModel);
                 previousDate = indexDate;
+                if (rowsViewModels.size() % 2 == 0) {
+                    rowsViewModels.add(new AdViewModel());
+                }
             }
 
             indexDate = indexDate.addDay(1);

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewType.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingRowViewType.java
@@ -5,19 +5,19 @@ import android.support.annotation.IntDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static com.alexstyl.specialdates.upcoming.UpcomingRowViewType.UPCOMING_EVENTS;
-import static com.alexstyl.specialdates.upcoming.UpcomingRowViewType.MONTH;
-import static com.alexstyl.specialdates.upcoming.UpcomingRowViewType.YEAR;
+import static com.alexstyl.specialdates.upcoming.UpcomingRowViewType.*;
 
 @Retention(RetentionPolicy.SOURCE)
 @IntDef({
         MONTH,
         UPCOMING_EVENTS,
-        YEAR
+        YEAR,
+        AD
 })
 public @interface UpcomingRowViewType {
 
     int MONTH = 0;
     int UPCOMING_EVENTS = 1;
     int YEAR = 2;
+    int AD = 3;
 }

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/AdViewHolder.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/AdViewHolder.java
@@ -1,0 +1,24 @@
+package com.alexstyl.specialdates.upcoming.view;
+
+import android.view.View;
+
+import com.alexstyl.specialdates.upcoming.AdViewModel;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.NativeExpressAdView;
+
+final class AdViewHolder extends UpcomingRowViewHolder<AdViewModel> {
+
+    private final NativeExpressAdView adView;
+
+    AdViewHolder(View convertView, NativeExpressAdView adView) {
+        super(convertView);
+        this.adView = adView;
+    }
+
+    @Override
+    public void bind(AdViewModel element, OnUpcomingEventClickedListener listener) {
+        // ads handle clicking by themselves
+        adView.loadAd(new AdRequest.Builder()
+                              .build());
+    }
+}

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingEventsListView.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingEventsListView.java
@@ -8,9 +8,11 @@ import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 
+import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.images.ImageLoader;
 import com.alexstyl.specialdates.images.PauseImageLoadingScrollListener;
 import com.alexstyl.specialdates.ui.widget.ScrollingLinearLayoutManager;
+import com.alexstyl.specialdates.ui.widget.SpacesItemDecoration;
 import com.alexstyl.specialdates.upcoming.UpcomingRowViewModel;
 
 import java.util.List;
@@ -35,6 +37,7 @@ public class UpcomingEventsListView extends RecyclerView {
         setAdapter(adapter);
 
         addOnScrollListener(PauseImageLoadingScrollListener.newInstance(imageLoader));
+        addItemDecoration(new SpacesItemDecoration(getResources().getDimensionPixelSize(R.dimen.upcoming_vertical_padding_between_cards), 1));
     }
 
     public void updateWith(List<UpcomingRowViewModel> dates, OnUpcomingEventClickedListener listener) {

--- a/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingViewHolderFactory.java
+++ b/mobile/src/main/java/com/alexstyl/specialdates/upcoming/view/UpcomingViewHolderFactory.java
@@ -8,8 +8,13 @@ import android.widget.TextView;
 import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.images.ImageLoader;
 import com.alexstyl.specialdates.upcoming.UpcomingRowViewType;
+import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.NativeExpressAdView;
 import com.novoda.notils.caster.Views;
 import com.novoda.notils.exception.DeveloperError;
+
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 final class UpcomingViewHolderFactory {
 
@@ -35,6 +40,12 @@ final class UpcomingViewHolderFactory {
             View view = layoutInflater.inflate(R.layout.row_header, parent, false);
             TextView headerView = (TextView) view.findViewById(R.id.upcoming_event_header);
             return new YearViewHolder(view, headerView);
+        } else if (viewType == UpcomingRowViewType.AD) {
+            NativeExpressAdView adView = new NativeExpressAdView(parent.getContext());
+            adView.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
+            adView.setAdSize(new AdSize(AdSize.FULL_WIDTH, 132));
+            adView.setAdUnitId(parent.getResources().getString(R.string.admob_unit_id));
+            return new AdViewHolder(adView, adView);
         } else {
             throw new DeveloperError("Invalid viewType " + viewType);
         }

--- a/mobile/src/main/res/layout/row_header.xml
+++ b/mobile/src/main/res/layout/row_header.xml
@@ -5,7 +5,7 @@
   style="@style/Upcoming.MonthHeader"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:layout_marginBottom="@dimen/upcoming_vertical_bottom_padding_between_each_card"
+  android:layout_marginBottom="@dimen/upcoming_vertical_padding_between_cards"
   android:layout_marginLeft="@dimen/upcoming_event_padding_horizontal"
   android:layout_marginRight="@dimen/upcoming_event_padding_horizontal"
   android:layout_marginTop="@dimen/padding_month_header_vertical"

--- a/mobile/src/main/res/layout/row_upcoming_day.xml
+++ b/mobile/src/main/res/layout/row_upcoming_day.xml
@@ -5,8 +5,6 @@
   style="@style/CardViewStyle"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:layout_marginBottom="@dimen/upcoming_vertical_bottom_padding_between_each_card"
-  android:layout_marginTop="@dimen/upcoming_vertical_top_padding_between_each_card"
   android:orientation="vertical"
   tools:showIn="@layout/activity_main">
 

--- a/mobile/src/main/res/values/admob.xml
+++ b/mobile/src/main/res/values/admob.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="admob_list_size"
+    translatable="false">360x132</string>
+</resources>

--- a/mobile/src/main/res/values/upcoming-resources.xml
+++ b/mobile/src/main/res/values/upcoming-resources.xml
@@ -4,8 +4,7 @@
   <string name="upcoming_events_namedays_title">@string/namedays</string>
   <string name="plus_x_more">+%d more</string>
 
-  <dimen name="upcoming_vertical_top_padding_between_each_card">8dp</dimen>
-  <dimen name="upcoming_vertical_bottom_padding_between_each_card">@dimen/upcoming_vertical_top_padding_between_each_card</dimen>
+  <dimen name="upcoming_vertical_padding_between_cards">12dp</dimen>
 
   <dimen name="upcoming_event_padding_vertical">8dp</dimen>
   <dimen name="upcoming_event_padding_horizontal">16dp</dimen>

--- a/mobile/src/test/java/com/alexstyl/specialdates/TestContact.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/TestContact.java
@@ -2,7 +2,6 @@ package com.alexstyl.specialdates;
 
 import android.content.Context;
 import android.net.Uri;
-import android.view.View;
 
 import com.alexstyl.specialdates.contact.Contact;
 import com.alexstyl.specialdates.contact.actions.LabeledAction;
@@ -26,7 +25,7 @@ public class TestContact extends Contact {
     }
 
     @Override
-    public void displayQuickInfo(Context context, View view) {
+    public void displayQuickInfo(Context context) {
         throw new UnsupportedOperationException("Not supported");
     }
 
@@ -34,7 +33,5 @@ public class TestContact extends Contact {
     public Uri getImagePath() {
         throw new UnsupportedOperationException("Not supported");
     }
-
-
 
 }

--- a/mobile/src/test/java/com/alexstyl/specialdates/contact/ContactTest.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/contact/ContactTest.java
@@ -2,7 +2,6 @@ package com.alexstyl.specialdates.contact;
 
 import android.content.Context;
 import android.net.Uri;
-import android.view.View;
 
 import com.alexstyl.specialdates.DisplayName;
 import com.alexstyl.specialdates.contact.actions.LabeledAction;
@@ -46,7 +45,7 @@ public class ContactTest {
         }
 
         @Override
-        public void displayQuickInfo(Context context, View view) {
+        public void displayQuickInfo(Context context) {
             throw new UnsupportedOperationException();
         }
 

--- a/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingEventsNoAdRules.java
+++ b/mobile/src/test/java/com/alexstyl/specialdates/upcoming/UpcomingEventsNoAdRules.java
@@ -1,0 +1,23 @@
+package com.alexstyl.specialdates.upcoming;
+
+final class UpcomingEventsNoAdRules implements UpcomingEventsAdRules {
+    @Override
+    public boolean shouldAppendAdForEndOfMonth(int index) {
+        return false;
+    }
+
+    @Override
+    public void onNewMonthAdded(int index) {
+        // do nothing
+    }
+
+    @Override
+    public boolean shouldAppendAdAt(int index) {
+        return false;
+    }
+
+    @Override
+    public void onNewAdAdded(int index) {
+        throw new IllegalStateException(UpcomingEventsNoAdRules.class.getName() + " does not allow ads to be added");
+    }
+}

--- a/secret.gradle.sample
+++ b/secret.gradle.sample
@@ -3,4 +3,5 @@ ext {
     crashlyticsKey = "1234567890123456789012345678901234567890"
     androidVendingKey = "Include your vending key here"
     mixpanelKey = "Include your mix panel key here"
+    adMobUnitId = "Your own admob unit id here"
 }


### PR DESCRIPTION
#### Description

Introduce AdMob adds into the Upcoming event list. Ads can be placed in two places on each month; one after 2 days after the first visible day of the month and one at the end of each month, unless an other ad is added close to the end.

##### Test(s) added

Updated the current ones

##### Screenshots
(if no visual change, just delete)

| Before | After |
| ------ | ----- |
| ![device-2017-02-08-235910](https://cloud.githubusercontent.com/assets/1665273/22763097/a0491444-ee5a-11e6-9f34-df1f6adfc504.png) | ![device-2017-02-08-235735](https://cloud.githubusercontent.com/assets/1665273/22763058/690be6a0-ee5a-11e6-9c00-2c4d39dd7113.png) |
