### PR TITLE
Change ErrorTracker logging to warning

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/ErrorTracker.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/ErrorTracker.java
@@ -36,7 +36,7 @@ public class ErrorTracker {
         if (hasBeenInitialised) {
             Crashlytics.logException(e);
         }
-        Log.e(e);
+        Log.w(e);
     }
 
     public static void onNamedayLocaleChanged(NamedayLocale locale) {


### PR DESCRIPTION
#### Description

This PR changes the logging done by the `ErrorTracker` to warning. It was previously logged as `error` making the logged errors hard to differentiate from actual errors (crashes). 