### PR TITLE
Move Facebook Import to menu

### DIFF
--- a/android_mobile/build.gradle
+++ b/android_mobile/build.gradle
@@ -97,8 +97,6 @@ dependencies {
 
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'io.reactivex.rxjava2:rxjava:2.1.0'
-    compile 'com.github.clans:fab:1.6.4'
-
 
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
     debugCompile 'com.facebook.stetho:stetho:1.3.0'

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
@@ -24,7 +24,6 @@ import com.alexstyl.specialdates.ui.ViewFader;
 import com.alexstyl.specialdates.ui.base.ThemedMementoActivity;
 import com.alexstyl.specialdates.upcoming.view.ExposedSearchToolbar;
 import com.alexstyl.specialdates.util.Notifier;
-import com.github.clans.fab.FloatingActionMenu;
 import com.novoda.notils.caster.Views;
 import com.novoda.notils.meta.AndroidUtils;
 
@@ -62,20 +61,10 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
 
         notifier = Notifier.newInstance(this);
 
-        final FloatingActionMenu fam = Views.findById(this, R.id.upcoming_events_fab);
         Views.findById(this, R.id.upcoming_events_add_event).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 navigator.toAddEvent();
-                fam.close(true);
-            }
-        });
-
-        Views.findById(this, R.id.upcoming_events_facebook).setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                navigator.toFacebookImport();
-                fam.close(true);
             }
         });
         askForSupport = new AskForSupport(this);
@@ -128,8 +117,12 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
             case R.id.action_donate:
                 navigator.toDonate();
                 return true;
+            case R.id.action_import_facebook:
+                navigator.toFacebookImport();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
         }
-        return super.onOptionsItemSelected(item);
     }
 
     private void showSelectDateDialog() {

--- a/android_mobile/src/main/res/layout/activity_upcoming_events.xml
+++ b/android_mobile/src/main/res/layout/activity_upcoming_events.xml
@@ -40,8 +40,8 @@
       tools:layout="@layout/fragment_upcoming_events" />
   </LinearLayout>
 
-  <com.github.clans.fab.FloatingActionMenu
-    android:id="@+id/upcoming_events_fab"
+  <android.support.design.widget.FloatingActionButton
+    android:id="@+id/upcoming_events_add_event"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
@@ -49,35 +49,7 @@
     android:layout_alignParentRight="true"
     android:layout_margin="@dimen/fab_margin"
     android:src="@drawable/ic_content_add"
-    app:menu_animationDelayPerItem="55"
-    app:menu_colorNormal="?colorAccent"
-    app:menu_colorPressed="?colorAccent"
-    app:menu_fab_size="normal"
-    app:menu_showShadow="true">
-
-
-    <com.github.clans.fab.FloatingActionButton
-      android:id="@+id/upcoming_events_facebook"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:src="@drawable/ic_facebook_logo_f"
-      app:fab_colorNormal="@color/facebook_blue"
-      app:fab_colorPressed="@color/facebook_blue"
-      app:fab_label="@string/title_facebook_friends_import"
-      app:fab_size="mini" />
-
-    <com.github.clans.fab.FloatingActionButton
-      android:id="@+id/upcoming_events_add_event"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:src="@drawable/ic_person_light_24dp"
-      app:fab_colorNormal="?colorAccent"
-      app:fab_colorPressed="?colorAccent"
-      app:fab_label="@string/add_event_title"
-      app:fab_size="mini" />
-
-  </com.github.clans.fab.FloatingActionMenu>
-
+    app:fabSize="normal" />
 
 </RelativeLayout>
 

--- a/android_mobile/src/main/res/menu/menu_mainactivity.xml
+++ b/android_mobile/src/main/res/menu/menu_mainactivity.xml
@@ -5,9 +5,15 @@
   <item
     android:id="@+id/action_select_date"
     android:icon="@drawable/ic_action_select_date"
-    android:orderInCategory="100"
+    android:orderInCategory="0"
     android:title="@string/upcoming_select_date"
-    app:showAsAction="always" />
+    app:showAsAction="ifRoom" />
+
+  <item
+    android:id="@+id/action_import_facebook"
+    android:title="@string/title_facebook_friends_import"
+    app:showAsAction="never" />
+
 
   <item
     android:id="@+id/action_settings"


### PR DESCRIPTION
#### Description

This PR moves the Import from Facebook to the overflow menu in the UpcomingEvents activity, from the '+' fab. 