### PR TITLE
Change the loading fb birthday url to the new one

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/facebook/login/FBImportClient.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/facebook/login/FBImportClient.java
@@ -10,6 +10,8 @@ class FBImportClient extends WebViewClient {
     private static final String HTTP = "http://";
     private static final String MOBILE_HOME = "m.facebook.com/home.php";
     private static final String DESKTOP_HOME = "www.facebook.com/home.php";
+    private static final String DESKTOP_USER_AGENT = "Mozilla/5.0 (X11; U; Linux i686; en   US; rv:1.9.0.4) Gecko/20100101 Firefox/4.0";
+    private static final String URL_WITH_BIRTHDAY_SOURCE = "https://www.facebook.com/events/calendar";
 
     private final WebView webView;
     private FacebookLogInCallback listener;
@@ -33,19 +35,18 @@ class FBImportClient extends WebViewClient {
 
     private void internalOnUserLoggedIn() {
         switchToDesktopBrowsing();
-        webView.loadUrl("http://www.facebook.com/events/birthdays");
+        webView.loadUrl(URL_WITH_BIRTHDAY_SOURCE);
         listener.onUserCredentialsSubmitted();
     }
 
     private void switchToDesktopBrowsing() {
         WebSettings settings = webView.getSettings();
-        String newUA = "Mozilla/5.0 (X11; U; Linux i686; en   US; rv:1.9.0.4) Gecko/20100101 Firefox/4.0";
-        settings.setUserAgentString(newUA);
+        settings.setUserAgentString(DESKTOP_USER_AGENT);
     }
 
     @Override
     public void onPageFinished(WebView view, String url) {
-        if (url.contains("facebook.com/events/birthdays")) {
+        if (url.contains(URL_WITH_BIRTHDAY_SOURCE)) {
             webView.loadUrl("javascript:window.HTMLOUT.processHTML('<head>'+document.getElementsByTagName('html')[0].innerHTML+'</head>');");
         }
     }


### PR DESCRIPTION
#### Description

Facebook seems to have changed the url from which the user can export their birthdays calendar to `https://www.facebook.com/events/calendar`. This PR uses that url in order to pick up the ical file from there.
