### PR TITLE
Drawer trigger + support dialog

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/support/AskForSupport.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/support/AskForSupport.java
@@ -26,7 +26,7 @@ public class AskForSupport {
         return timeSinceLastRate > RETRY_INTERVAL;
     }
 
-    public void onRateEnd() {
+    void onRateEnd() {
         preferences.setHasUserRated(true);
     }
 

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/support/CallForRatingPreferences.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/support/CallForRatingPreferences.java
@@ -5,43 +5,44 @@ import android.content.Context;
 import com.alexstyl.specialdates.EasyPreferences;
 import com.alexstyl.specialdates.R;
 
-public class CallForRatingPreferences {
+class CallForRatingPreferences {
 
     private EasyPreferences preferences;
 
-    public CallForRatingPreferences(Context context) {
+    CallForRatingPreferences(Context context) {
         preferences = EasyPreferences.createForPrivatePreferences(context, R.string.pref_call_to_rate);
     }
 
-    public boolean hasUserRated() {
+    boolean hasUserRated() {
         return preferences.getBoolean(R.string.key_has_user_rated, false);
     }
 
-    public void setHasUserRated(boolean value) {
+    void setHasUserRated(boolean value) {
         preferences.setBoolean(R.string.key_has_user_rated, value);
     }
 
-    public long lastAskTimeAsked() {
+    long lastAskTimeAsked() {
         long previousTime = preferences.getLong(R.string.key_rate_previous_time_asked, -1);
         if (previousTime == -1) {
             preferences.setLong(R.string.key_rate_previous_time_asked, System.currentTimeMillis());
+            previousTime = System.currentTimeMillis();
         }
         return previousTime;
     }
 
-    public void triggerNextTime() {
+    void triggerNextTime() {
         preferences.setBoolean(R.string.key_rate_triggered, true);
     }
 
-    public void resetTrigger() {
+    void resetTrigger() {
         preferences.setBoolean(R.string.key_rate_triggered, false);
     }
 
-    public boolean isTriggered() {
+    boolean isTriggered() {
         return preferences.getBoolean(R.string.key_rate_triggered, false);
     }
 
-    public void setLastAskTimedNow() {
+    void setLastAskTimedNow() {
         preferences.setLong(R.string.key_rate_previous_time_asked, System.currentTimeMillis());
     }
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
@@ -136,10 +136,10 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
 
     private void setupDrawerListener() {
         drawerLayout.addDrawerListener(new DrawerLayout.SimpleDrawerListener() {
-
             @Override
             public void onDrawerOpened(View drawerView) {
                 preferences.setUserKnowsDrawer();
+                drawerLayout.removeDrawerListener(this);
             }
         });
     }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
@@ -40,7 +40,6 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
 
     private static final long DRAWER_APPEARANCE_WAITING_TIME = 400L;
 
-
     private ThemeMonitor themeMonitor;
 
     private UpcomingEventsNavigator navigator;
@@ -129,9 +128,20 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
                 public void run() {
                     drawerLayout.openDrawer(Gravity.START, true);
                     preferences.triggerNavigationDrawerDisplayed();
+                    setupDrawerListener();
                 }
             }, DRAWER_APPEARANCE_WAITING_TIME);
         }
+    }
+
+    private void setupDrawerListener() {
+        drawerLayout.addDrawerListener(new DrawerLayout.SimpleDrawerListener() {
+
+            @Override
+            public void onDrawerOpened(View drawerView) {
+                preferences.setUserKnowsDrawer();
+            }
+        });
     }
 
     @Override

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsActivity.java
@@ -23,7 +23,6 @@ import com.alexstyl.specialdates.dailyreminder.DailyReminderNotifier;
 import com.alexstyl.specialdates.date.Date;
 import com.alexstyl.specialdates.facebook.FacebookPreferences;
 import com.alexstyl.specialdates.images.ImageLoader;
-import com.alexstyl.specialdates.support.AskForSupport;
 import com.alexstyl.specialdates.theming.ThemeMonitor;
 import com.alexstyl.specialdates.theming.ThemingPreferences;
 import com.alexstyl.specialdates.ui.ViewFader;
@@ -41,7 +40,7 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
 
     private static final long DRAWER_APPEARANCE_WAITING_TIME = 400L;
 
-    private AskForSupport askForSupport;
+
     private ThemeMonitor themeMonitor;
 
     private UpcomingEventsNavigator navigator;
@@ -82,7 +81,6 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
                 navigator.toAddEvent();
             }
         });
-        askForSupport = new AskForSupport(this);
 
         setTitle(R.string.app_name);
 
@@ -133,14 +131,6 @@ public class UpcomingEventsActivity extends ThemedMementoActivity implements Dat
                     preferences.triggerNavigationDrawerDisplayed();
                 }
             }, DRAWER_APPEARANCE_WAITING_TIME);
-        }
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-        if (askForSupport.shouldAskForRating()) {
-            askForSupport.askForRatingFromUser(this);
         }
     }
 

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsFragment.java
@@ -29,6 +29,7 @@ import com.alexstyl.specialdates.permissions.ContactPermissionRequest;
 import com.alexstyl.specialdates.permissions.ContactPermissionRequest.PermissionCallbacks;
 import com.alexstyl.specialdates.permissions.PermissionChecker;
 import com.alexstyl.specialdates.permissions.PermissionNavigator;
+import com.alexstyl.specialdates.support.AskForSupport;
 import com.alexstyl.specialdates.ui.base.MementoFragment;
 import com.alexstyl.specialdates.ui.widget.SpacesItemDecoration;
 import com.alexstyl.specialdates.upcoming.view.OnUpcomingEventClickedListener;
@@ -52,6 +53,8 @@ public class UpcomingEventsFragment extends MementoFragment implements UpcomingL
     private UpcomingEventsAdapter adapter;
     private UpcomingEventsNavigator navigator;
     private ContactPermissionRequest permissions;
+    private AskForSupport askForSupport;
+
     @Inject Analytics analytics;
     @Inject Strings strings;
     @Inject ColorResources colorResources;
@@ -74,6 +77,8 @@ public class UpcomingEventsFragment extends MementoFragment implements UpcomingL
 
         AppComponent applicationModule = ((MementoApplication) getActivity().getApplication()).getApplicationModule();
         applicationModule.inject(this);
+
+        askForSupport = new AskForSupport(getActivity());
 
         permissions = new ContactPermissionRequest(
                 new PermissionNavigator(getActivity(), analytics),
@@ -147,6 +152,10 @@ public class UpcomingEventsFragment extends MementoFragment implements UpcomingL
         } else {
             upcomingList.setVisibility(View.GONE);
             emptyView.setVisibility(View.VISIBLE);
+        }
+
+        if (askForSupport.shouldAskForRating()) {
+            askForSupport.askForRatingFromUser(getActivity());
         }
     }
 

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsPreferences.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsPreferences.java
@@ -20,7 +20,8 @@ final class UpcomingEventsPreferences {
     }
 
     boolean isTheUserAwareOfNavigationDrawer() {
-        return preferences.getInt(R.string.key_navigation_times_viewed, 0) > MIN_TIMES_TO_VIEW_DRAWER;
+        return preferences.getBoolean(R.string.key_navigation_drawer_user_knows, false)
+                || preferences.getInt(R.string.key_navigation_times_viewed, 0) > MIN_TIMES_TO_VIEW_DRAWER;
     }
 
     void triggerNavigationDrawerDisplayed() {
@@ -28,4 +29,7 @@ final class UpcomingEventsPreferences {
         preferences.setInteger(R.string.key_navigation_times_viewed, times + 1);
     }
 
+    void setUserKnowsDrawer() {
+        preferences.setBoolean(R.string.key_navigation_drawer_user_knows, true);
+    }
 }

--- a/android_mobile/src/main/res/values/keys.xml
+++ b/android_mobile/src/main/res/values/keys.xml
@@ -48,5 +48,6 @@
   <string name="key_facebook_user_key">key_facebook_user_key</string>
   <string name="key_facebook_user_name">key_facebook_user_name</string>
   <string name="key_navigation_times_viewed">key_times_viewed_navigation</string>
+  <string name="key_navigation_drawer_user_knows">key_navigation_drawer_user_knows</string>
 
 </resources>


### PR DESCRIPTION
#### Description

This PR ensures that the drawer will stop being visible when the user opens the drawer knowingly.
Additionally, it makes the Ask for Support dialog to appear only after we are done showing events on the screen instead of when the UpcomingEventsFragment gets shown to the screen, so that we don't clash with the Permission activity.
