### PR TITLE
Use AlarmManager#setAndAllowWhileIdle for API 23+

### DIFF
--- a/android_common/src/main/java/com/alexstyl/android/AlarmManagerCompat.java
+++ b/android_common/src/main/java/com/alexstyl/android/AlarmManagerCompat.java
@@ -17,7 +17,9 @@ public final class AlarmManagerCompat {
     }
 
     public void setExact(int type, long triggerAtmillis, PendingIntent operation) {
-        if (Version.hasKitKat()) {
+        if (Version.hasMarshmallow()) {
+            alarmManager.setAndAllowWhileIdle(type, triggerAtmillis, operation);
+        } else if (Version.hasKitKat()) {
             alarmManager.setExact(type, triggerAtmillis, operation);
         } else {
             alarmManager.set(AlarmManager.RTC, triggerAtmillis, operation);

--- a/android_common/src/main/java/com/alexstyl/android/Version.java
+++ b/android_common/src/main/java/com/alexstyl/android/Version.java
@@ -38,4 +38,7 @@ public final class Version {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
+    static boolean hasMarshmallow() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
 }


### PR DESCRIPTION
#### Description

There are some reports of the Daily reminder not firing sometimes. This could be due to Doze mode, that makes the device go to sleep without allowing apps to wake it up. In this PR we are using the [AlarmManager#setAndAllowWhileIdle](https://developer.android.com/reference/android/app/AlarmManager.html#setAndAllowWhileIdle(int,%20long,%20android.app.PendingIntent)) which was created for such scenarios similar to the Daily Reminder; calendar apps notifications.