### PR TITLE
Move monitoring of contacts to a dedicated service

### DIFF
--- a/android_mobile/src/main/AndroidManifest.xml
+++ b/android_mobile/src/main/AndroidManifest.xml
@@ -1,227 +1,229 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.alexstyl.specialdates"
-  android:installLocation="internalOnly">
+    package="com.alexstyl.specialdates"
+    android:installLocation="internalOnly">
 
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-  <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.READ_CONTACTS" />
-  <uses-permission android:name="android.permission.WRITE_CONTACTS" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-  <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
-  <!-- The BLUETOOTH permission is used for mixpanel-->
-  <uses-permission android:name="android.permission.BLUETOOTH" />
+    <!-- The BLUETOOTH permission is used for mixpanel-->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
-  <uses-permission android:name="com.android.vending.BILLING" />
+    <uses-permission android:name="com.android.vending.BILLING" />
 
-  <uses-feature
-    android:name="android.hardware.camera"
-    android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
-  <application
-    android:name="com.alexstyl.specialdates.MementoApplication"
-    android:allowBackup="true"
-    android:icon="@mipmap/ic_launcher"
-    android:label="@string/localised_app_name">
+    <application
+        android:name="com.alexstyl.specialdates.MementoApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/localised_app_name">
 
-    <activity android:name="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
+        <activity android:name="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
 
-    <!-- Activity alias used so that we can modify the UpcomingEventsActivity file without worrying about the name -->
-    <activity-alias
-      android:name="com.alexstyl.specialdates.ui.activity.MainActivity"
-      android:targetActivity=".upcoming.UpcomingEventsActivity">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity-alias>
-
-
-    <activity
-      android:name="com.alexstyl.specialdates.settings.MainPreferenceActivity"
-      android:label="@string/action_settings"
-      android:parentActivityName=".upcoming.UpcomingEventsActivity">
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value=".upcoming.UpcomingEventsActivity" />
-    </activity>
+        <!-- Activity alias used so that we can modify the UpcomingEventsActivity file without worrying about the name -->
+        <activity-alias
+            android:name="com.alexstyl.specialdates.ui.activity.MainActivity"
+            android:targetActivity=".upcoming.UpcomingEventsActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
 
 
-    <activity
-      android:name="com.alexstyl.specialdates.search.SearchActivity"
-      android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
-      android:windowSoftInputMode="stateVisible|adjustResize">
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
-    </activity>
+        <activity
+            android:name="com.alexstyl.specialdates.settings.MainPreferenceActivity"
+            android:label="@string/action_settings"
+            android:parentActivityName=".upcoming.UpcomingEventsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".upcoming.UpcomingEventsActivity" />
+        </activity>
 
 
-    <activity
-      android:name=".settings.DailyReminderActivity"
-      android:exported="true"
-      android:label="@string/daily_reminder"
-      android:parentActivityName=".settings.MainPreferenceActivity">
-      <intent-filter>
-        <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
-      </intent-filter>
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value=".settings.MainPreferenceActivity" />
-    </activity>
-
-    <activity
-      android:name="com.alexstyl.specialdates.addevent.AddEventActivity"
-      android:exported="true"
-      android:label="@string/add_event_title"
-      android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
-      android:screenOrientation="portrait"
-      android:windowSoftInputMode="stateHidden">
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
-    </activity>
+        <activity
+            android:name="com.alexstyl.specialdates.search.SearchActivity"
+            android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
+            android:windowSoftInputMode="stateVisible|adjustResize">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
+        </activity>
 
 
-    <activity
-      android:name="com.alexstyl.specialdates.support.RateDialog"
-      android:label="@string/support_app"
-      android:noHistory="true"
-      android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
-      android:theme="@style/Theme.Dayslight.DialogNoTitle">
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
-    </activity>
+        <activity
+            android:name=".settings.DailyReminderActivity"
+            android:exported="true"
+            android:label="@string/daily_reminder"
+            android:parentActivityName=".settings.MainPreferenceActivity">
+            <intent-filter>
+                <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
+            </intent-filter>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".settings.MainPreferenceActivity" />
+        </activity>
 
-    <activity
-      android:name=".upcoming.widget.today.UpcomingWidgetConfigureActivity"
-      android:label="@string/Configure_widget"
-      android:noHistory="true">
-      <intent-filter>
-        <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
-      </intent-filter>
-    </activity>
+        <activity
+            android:name="com.alexstyl.specialdates.addevent.AddEventActivity"
+            android:exported="true"
+            android:label="@string/add_event_title"
+            android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="stateHidden">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
+        </activity>
 
-    <activity
-      android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat" />
+
+        <activity
+            android:name="com.alexstyl.specialdates.support.RateDialog"
+            android:label="@string/support_app"
+            android:noHistory="true"
+            android:parentActivityName="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity"
+            android:theme="@style/Theme.Dayslight.DialogNoTitle">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.alexstyl.specialdates.upcoming.UpcomingEventsActivity" />
+        </activity>
+
+        <activity
+            android:name=".upcoming.widget.today.UpcomingWidgetConfigureActivity"
+            android:label="@string/Configure_widget"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:theme="@style/Base.Theme.AppCompat" />
 
 
-    <activity android:name=".permissions.ContactPermissionActivity" />
+        <activity android:name=".permissions.ContactPermissionActivity" />
 
-    <activity
-      android:name=".donate.DonateActivity"
-      android:label="@string/donate_welcome"
-      android:parentActivityName=".upcoming.UpcomingEventsActivity"
-      android:theme="@style/Theme.Donate" />
+        <activity
+            android:name=".donate.DonateActivity"
+            android:label="@string/donate_welcome"
+            android:parentActivityName=".upcoming.UpcomingEventsActivity"
+            android:theme="@style/Theme.Donate" />
 
-    <activity
-      android:name=".facebook.login.FacebookLogInActivity"
-      android:label="@string/title_facebook_log_in" />
+        <activity
+            android:name=".facebook.login.FacebookLogInActivity"
+            android:label="@string/title_facebook_log_in" />
 
-    <activity
-      android:name=".facebook.FacebookProfileActivity"
-      android:label="@string/title_facebook_profile" />
+        <activity
+            android:name=".facebook.FacebookProfileActivity"
+            android:label="@string/title_facebook_profile" />
 
-    <activity
-      android:name=".person.PersonActivity"
-      android:parentActivityName=".upcoming.UpcomingEventsActivity">
+        <activity
+            android:name=".person.PersonActivity"
+            android:parentActivityName=".upcoming.UpcomingEventsActivity">
 
-      <intent-filter>
-        <action android:name="com.android.contacts.action.QUICK_CONTACT" />
-        <action android:name="android.provider.action.QUICK_CONTACT" />
+            <intent-filter>
+                <action android:name="com.android.contacts.action.QUICK_CONTACT" />
+                <action android:name="android.provider.action.QUICK_CONTACT" />
 
-        <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.DEFAULT" />
 
-        <data android:mimeType="vnd.android.cursor.item/contact" />
-        <data android:mimeType="vnd.android.cursor.item/person" />
-      </intent-filter>
+                <data android:mimeType="vnd.android.cursor.item/contact" />
+                <data android:mimeType="vnd.android.cursor.item/person" />
+            </intent-filter>
 
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
 
-        <data android:mimeType="vnd.android.cursor.item/person" />
-        <data android:mimeType="vnd.android.cursor.item/contact" />
-        <data android:mimeType="vnd.android.cursor.item/raw_contact" />
-      </intent-filter>
+                <data android:mimeType="vnd.android.cursor.item/person" />
+                <data android:mimeType="vnd.android.cursor.item/contact" />
+                <data android:mimeType="vnd.android.cursor.item/raw_contact" />
+            </intent-filter>
 
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value=".upcoming.UpcomingEventsActivity" />
-    </activity>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".upcoming.UpcomingEventsActivity" />
+        </activity>
 
-    <activity
-      android:name=".events.namedays.activity.NamedayActivity"
-      android:parentActivityName=".upcoming.UpcomingEventsActivity">
-      <meta-data
-        android:name="android.support.PARENT_ACTIVITY"
-        android:value=".upcoming.UpcomingEventsActivity" />
-    </activity>
+        <activity
+            android:name=".events.namedays.activity.NamedayActivity"
+            android:parentActivityName=".upcoming.UpcomingEventsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".upcoming.UpcomingEventsActivity" />
+        </activity>
 
-    <activity android:name=".upcoming.widget.list.WidgetRouterActivity" />
+        <activity android:name=".upcoming.widget.list.WidgetRouterActivity" />
 
-    <!-- Services -->
-    <service
-      android:name="com.alexstyl.specialdates.dailyreminder.DailyReminderIntentService"
-      android:label="@string/service_dailyreminder" />
+        <!-- Services -->
+        <service
+            android:name="com.alexstyl.specialdates.dailyreminder.DailyReminderIntentService"
+            android:label="@string/service_dailyreminder" />
 
-    <service
-      android:name="com.alexstyl.specialdates.wear.WearSyncService"
-      android:exported="false" />
+        <service
+            android:name="com.alexstyl.specialdates.wear.WearSyncService"
+            android:exported="false" />
 
-    <receiver android:name="com.alexstyl.specialdates.DeviceConfigurationUpdatedReceiver">
-      <intent-filter>
-        <action android:name="android.intent.action.LOCALE_CHANGED" />
-      </intent-filter>
-    </receiver>
+        <receiver android:name="com.alexstyl.specialdates.DeviceConfigurationUpdatedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
+            </intent-filter>
+        </receiver>
 
-    <receiver android:name="com.alexstyl.specialdates.receiver.BootCompleteReceiver">
-      <intent-filter>
-        <action android:name="android.intent.action.TIME_SET" />
-        <action android:name="android.intent.action.BOOT_COMPLETED" />
-      </intent-filter>
-    </receiver>
+        <receiver android:name="com.alexstyl.specialdates.receiver.BootCompleteReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
-    <receiver
-      android:name=".upcoming.widget.today.TodayAppWidgetProvider"
-      android:label="@string/widget_upcoming_title_simple">
-      <intent-filter>
-        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-      </intent-filter>
+        <receiver
+            android:name=".upcoming.widget.today.TodayAppWidgetProvider"
+            android:label="@string/widget_upcoming_title_simple">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
 
-      <meta-data
-        android:name="android.appwidget.provider"
-        android:resource="@xml/widget_info_upcoming_events_simple" />
-    </receiver>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info_upcoming_events_simple" />
+        </receiver>
 
-    <receiver
-      android:name=".upcoming.widget.list.UpcomingEventsScrollingAppWidgetProvider"
-      android:label="@string/widget_upcoming_title_list">
-      <intent-filter>
-        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-      </intent-filter>
+        <receiver
+            android:name=".upcoming.widget.list.UpcomingEventsScrollingAppWidgetProvider"
+            android:label="@string/widget_upcoming_title_list">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
 
-      <meta-data
-        android:name="android.appwidget.provider"
-        android:resource="@xml/widget_info_upcoming_events_list" />
-    </receiver>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info_upcoming_events_list" />
+        </receiver>
 
-    <service
-      android:name=".upcoming.widget.list.UpcomingEventsRemoteViewService"
-      android:permission="android.permission.BIND_REMOTEVIEWS" />
+        <service
+            android:name=".upcoming.widget.list.UpcomingEventsRemoteViewService"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
 
-    <service
-      android:name=".facebook.friendimport.FacebookFriendsIntentService"
-      android:label="@string/title_facebook_friends_import" />
+        <service
+            android:name=".facebook.friendimport.FacebookFriendsIntentService"
+            android:label="@string/title_facebook_friends_import" />
 
-    <meta-data
-      android:name="io.fabric.ApiKey"
-      android:value="${crashlyticsApiKey}" />
-  </application>
+        <service android:name=".contact.ContactMonitorService" />
+
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="${crashlyticsApiKey}" />
+    </application>
 
 </manifest>

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/AppComponent.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/AppComponent.java
@@ -5,6 +5,7 @@ import com.alexstyl.specialdates.addevent.AddEventActivity;
 import com.alexstyl.specialdates.addevent.EventDatePickerDialogFragment;
 import com.alexstyl.specialdates.addevent.ui.ContactSuggestionView;
 import com.alexstyl.specialdates.analytics.AnalyticsModule;
+import com.alexstyl.specialdates.contact.ContactMonitorService;
 import com.alexstyl.specialdates.contact.ContactsModule;
 import com.alexstyl.specialdates.dailyreminder.DailyReminderIntentService;
 import com.alexstyl.specialdates.dailyreminder.DailyReminderModule;
@@ -118,4 +119,6 @@ public interface AppComponent {
     void inject(ContactPermissionActivity activity);
 
     void inject(BootCompleteReceiver receiver);
+
+    void inject(ContactMonitorService contactMonitorService);
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/contact/ContactMonitorService.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/contact/ContactMonitorService.java
@@ -1,0 +1,84 @@
+package com.alexstyl.specialdates.contact;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import com.alexstyl.specialdates.AppComponent;
+import com.alexstyl.specialdates.EasyPreferences;
+import com.alexstyl.specialdates.ErrorTracker;
+import com.alexstyl.specialdates.MementoApplication;
+import com.alexstyl.specialdates.R;
+import com.alexstyl.specialdates.events.ContactsObserver;
+import com.alexstyl.specialdates.events.PeopleEventsMonitor;
+import com.alexstyl.specialdates.events.PreferenceChangedEventsUpdateTrigger;
+import com.alexstyl.specialdates.events.peopleevents.EventPreferences;
+import com.alexstyl.specialdates.permissions.PermissionChecker;
+import com.novoda.notils.logger.simple.Log;
+
+import java.util.concurrent.Callable;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+import static java.util.Arrays.asList;
+
+public class ContactMonitorService extends Service {
+
+    @Inject
+    PeopleEventsMonitor eventsMonitor;
+    @Inject
+    EventPreferences eventPreferences;
+
+    PreferenceChangedEventsUpdateTrigger preferenceChangedEventsUpdateTrigger;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AppComponent applicationModule = ((MementoApplication) getApplication()).getApplicationModule();
+        applicationModule.inject(this);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        setupDatabaseRefresher();
+        return START_STICKY;
+    }
+
+    private void setupDatabaseRefresher() {
+        preferenceChangedEventsUpdateTrigger = new PreferenceChangedEventsUpdateTrigger(
+                EasyPreferences.createForDefaultPreferences(this),
+                getResources(),
+                R.string.key_enable_namedays,
+                R.string.key_nameday_lang,
+                R.string.key_namedays_full_name
+        );
+
+        eventsMonitor.startMonitoring(
+                asList(
+                        new ContactsObserver(getContentResolver()),
+                        preferenceChangedEventsUpdateTrigger
+                ));
+
+        boolean eventsHaveBeenInitialised = eventPreferences.hasBeenInitialised();
+        if (!eventsHaveBeenInitialised) {
+            Observable.fromCallable(new Callable<Integer>() {
+                @Override
+                public Integer call() {
+                    eventsMonitor.updateEvents();
+                    eventPreferences.markEventsAsInitialised();
+                    return 5;
+                }
+            })
+                    .subscribe();
+        }
+    }
+}

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/ContactPermissionActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/ContactPermissionActivity.java
@@ -2,6 +2,7 @@ package com.alexstyl.specialdates.permissions;
 
 import android.Manifest;
 import android.annotation.TargetApi;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -10,6 +11,7 @@ import android.view.View;
 import android.widget.Button;
 
 import com.alexstyl.specialdates.R;
+import com.alexstyl.specialdates.contact.ContactMonitorService;
 import com.alexstyl.specialdates.ui.base.ThemedMementoActivity;
 import com.novoda.notils.caster.Views;
 
@@ -44,8 +46,14 @@ public class ContactPermissionActivity extends ThemedMementoActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == REQUEST_CONTACT_PERMISSION && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            launchMonitorService();
             setResult(RESULT_OK);
             finish();
         }
+    }
+
+    private void launchMonitorService() {
+        Intent intent = new Intent(this, ContactMonitorService.class);
+        startService(intent);
     }
 }


### PR DESCRIPTION
#### Description

This PR moves the logic of the monitoring of the contacts to a separate `ContactMonitorService`. The services gets launched on app launch, only if the contacts permissions is present. When the user grants us the contact permission, the service gets launched then.