### PR TITLE
Ask for both READ_CONTACTS & WRITE_CONTACTS permissions

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/ContactPermissionActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/ContactPermissionActivity.java
@@ -39,7 +39,9 @@ public class ContactPermissionActivity extends ThemedMementoActivity {
     };
 
     private void requestContactPermission() {
-        requestPermissions(new String[]{Manifest.permission.READ_CONTACTS}, REQUEST_CONTACT_PERMISSION);
+        requestPermissions(new String[]{Manifest.permission.READ_CONTACTS,
+                        Manifest.permission.WRITE_CONTACTS}
+                , REQUEST_CONTACT_PERMISSION);
     }
 
     @Override

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/PermissionChecker.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/permissions/PermissionChecker.java
@@ -8,6 +8,7 @@ import com.alexstyl.specialdates.ErrorTracker;
 
 import static android.Manifest.permission.READ_CONTACTS;
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
+import static android.Manifest.permission.WRITE_CONTACTS;
 
 public class PermissionChecker {
     private final Context context;
@@ -17,7 +18,7 @@ public class PermissionChecker {
     }
 
     public boolean canReadAndWriteContacts() {
-        return hasPermission(context, READ_CONTACTS);
+        return hasPermission(context, READ_CONTACTS) && hasPermission(context, WRITE_CONTACTS);
     }
 
     public boolean canReadExternalStorage() {


### PR DESCRIPTION
The app seems to crash when the user is trying to create a new contact or edit one in the Add Event screen. This is because the WRITE_CONTACTS permissions is never granted. This PR includes both READ and WRITE permissions when requesting the contacts permissions from the user.