### PR TITLE
Add option to show contact via other apps

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/AddEventViewModelFactory.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/AddEventViewModelFactory.kt
@@ -10,7 +10,10 @@ import com.alexstyl.specialdates.events.peopleevents.StandardEventType
 
 internal class AddEventViewModelFactory(private val strings: Strings) {
 
-    private val NO_DATE = Optional.absent<Date>()
+
+    companion object {
+        private val NO_DATE = Optional.absent<Date>()
+    }
 
     fun createViewModelsForAllEventsBut(existingTypes: List<EventType>): List<AddEventContactEventViewModel> {
         val addEventViewModels = ArrayList<AddEventContactEventViewModel>()

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/bottomsheet/IntentResolver.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/bottomsheet/IntentResolver.java
@@ -8,15 +8,15 @@ import android.graphics.drawable.Drawable;
 import java.util.ArrayList;
 import java.util.List;
 
-final class IntentResolver {
+public final class IntentResolver {
 
     private final PackageManager packageManager;
 
-    IntentResolver(PackageManager packageManager) {
+    public IntentResolver(PackageManager packageManager) {
         this.packageManager = packageManager;
     }
 
-    List<IntentOptionViewModel> createViewModelsFor(Intent intent) {
+    public List<IntentOptionViewModel> createViewModelsFor(Intent intent) {
         List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(intent, 0);
         List<IntentOptionViewModel> viewModels = new ArrayList<>(resolveInfos.size());
         for (ResolveInfo resolveInfo : resolveInfos) {

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentAdapter.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentAdapter.java
@@ -1,0 +1,48 @@
+package com.alexstyl.specialdates.person;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.alexstyl.specialdates.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class BottomSheetIntentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+
+    private final List<IntentOptionViewModel> viewModels;
+    private final BottomSheetIntentListener listener;
+
+    BottomSheetIntentAdapter(BottomSheetIntentListener listener, List<IntentOptionViewModel> viewModels) {
+        this.viewModels = new ArrayList<>();
+        this.viewModels.addAll(viewModels);
+        this.listener = listener;
+    }
+
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.row_image_option, parent, false);
+        ImageView iconView = view.findViewById(R.id.pick_image_activity_icon);
+        TextView labelView = view.findViewById(R.id.pick_image_activity_label);
+        return new IntentOptionViewHolder(view, iconView, labelView);
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+        IntentOptionViewModel viewModel = viewModels.get(position);
+        ((IntentOptionViewHolder) holder).bind(viewModel, listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return viewModels.size();
+    }
+
+}
+

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentDialog.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentDialog.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.specialdates.person
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Dialog
 import android.content.Intent
@@ -17,10 +18,10 @@ import com.novoda.notils.caster.Views.findById
 
 
 class BottomSheetIntentDialog : MementoDialog() {
-    private var KEY_INTENTS = "key:intents"
-    private val KEY_TITLE = "key:title"
 
     companion object {
+        private const val KEY_INTENTS = "key:intents"
+        private const val KEY_TITLE = "key:title"
 
         fun newIntent(title: String, intents: ArrayList<Intent>): BottomSheetIntentDialog {
             return BottomSheetIntentDialog().apply {
@@ -34,11 +35,13 @@ class BottomSheetIntentDialog : MementoDialog() {
 
     lateinit var listener: BottomSheetIntentListener
 
+    @Suppress("OverridingDeprecatedMember", "DEPRECATION")
     override fun onAttach(activity: Activity?) {
         super.onAttach(activity)
         this.listener = Classes.from(activity)
     }
 
+    @SuppressLint("InflateParams")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = activity
         val dialog = BottomSheetDialog(context!!)
@@ -60,13 +63,13 @@ class BottomSheetIntentDialog : MementoDialog() {
 
         val createViewModelsFor = createViewModelsFor(intents)
         val adapter = BottomSheetIntentAdapter(listener, createViewModelsFor)
-        grid.setAdapter(adapter)
+        grid.adapter = adapter
 
         dialog.setContentView(view)
         return dialog
     }
 
-    fun createViewModelsFor(intents: List<Intent>): List<IntentOptionViewModel> {
+    private fun createViewModelsFor(intents: List<Intent>): List<IntentOptionViewModel> {
         val packageManager = context!!.packageManager
         val viewModels = ArrayList<IntentOptionViewModel>(intents.size)
 

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentDialog.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentDialog.kt
@@ -1,0 +1,86 @@
+package com.alexstyl.specialdates.person
+
+import android.app.Activity
+import android.app.Dialog
+import android.content.Intent
+import android.os.Bundle
+import android.support.design.widget.BottomSheetDialog
+import android.support.v7.widget.GridLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.widget.TextView
+import com.alexstyl.specialdates.R
+import com.alexstyl.specialdates.ui.base.MementoDialog
+import com.alexstyl.specialdates.ui.widget.SpacesItemDecoration
+import com.novoda.notils.caster.Classes
+import com.novoda.notils.caster.Views.findById
+
+
+class BottomSheetIntentDialog : MementoDialog() {
+    private var KEY_INTENTS = "key:intents"
+    private val KEY_TITLE = "key:title"
+
+    companion object {
+
+        fun newIntent(title: String, intents: ArrayList<Intent>): BottomSheetIntentDialog {
+            return BottomSheetIntentDialog().apply {
+                val bundle = Bundle()
+                bundle.putParcelableArrayList(KEY_INTENTS, intents)
+                bundle.putString(KEY_TITLE, title)
+                this.arguments = bundle
+            }
+        }
+    }
+
+    lateinit var listener: BottomSheetIntentListener
+
+    override fun onAttach(activity: Activity?) {
+        super.onAttach(activity)
+        this.listener = Classes.from(activity)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = activity
+        val dialog = BottomSheetDialog(context!!)
+        val layoutInflater = LayoutInflater.from(context)
+        val view = layoutInflater.inflate(R.layout.dialog_bottom_dialog, null, false)
+
+        val title = view.findViewById<TextView>(R.id.bottom_sheet_title)
+        title.text = arguments?.getString(KEY_TITLE)
+
+        val grid = findById<RecyclerView>(view, R.id.bottom_sheet_grid)
+        val gridLayoutManager = GridLayoutManager(context, resources.getInteger(R.integer.bottom_sheet_span_count))
+        grid.addItemDecoration(SpacesItemDecoration(
+                resources.getDimensionPixelSize(R.dimen.add_event_image_option_vertical),
+                gridLayoutManager.spanCount
+        ))
+        grid.layoutManager = gridLayoutManager
+
+        val intents = arguments?.get(KEY_INTENTS) as ArrayList<Intent>
+
+        val createViewModelsFor = createViewModelsFor(intents)
+        val adapter = BottomSheetIntentAdapter(listener, createViewModelsFor)
+        grid.setAdapter(adapter)
+
+        dialog.setContentView(view)
+        return dialog
+    }
+
+    fun createViewModelsFor(intents: List<Intent>): List<IntentOptionViewModel> {
+        val packageManager = context!!.packageManager
+        val viewModels = ArrayList<IntentOptionViewModel>(intents.size)
+
+        for (intent in intents) {
+            val resolveInfos = packageManager.queryIntentActivities(intent, 0)
+            for (resolveInfo in resolveInfos) {
+                val icon = resolveInfo.loadIcon(packageManager)
+                val label = resolveInfo.loadLabel(packageManager).toString()
+                val launchingIntent = Intent(intent.action)
+                launchingIntent.data = intent.data
+                launchingIntent.setClassName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name)
+                viewModels.add(IntentOptionViewModel(icon, label, launchingIntent))
+            }
+        }
+        return viewModels
+    }
+}

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentListener.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/BottomSheetIntentListener.java
@@ -1,0 +1,7 @@
+package com.alexstyl.specialdates.person;
+
+import android.content.Intent;
+
+public interface BottomSheetIntentListener {
+    void onActivitySelected(Intent intent);
+}

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/IntentOptionViewHolder.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/IntentOptionViewHolder.java
@@ -1,0 +1,31 @@
+package com.alexstyl.specialdates.person;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.alexstyl.specialdates.addevent.bottomsheet.BottomSheetPicturesDialog.Listener;
+
+final class IntentOptionViewHolder extends RecyclerView.ViewHolder {
+
+    private final ImageView iconView;
+    private final TextView labelView;
+
+    IntentOptionViewHolder(View view, ImageView iconView, TextView labelView) {
+        super(view);
+        this.iconView = iconView;
+        this.labelView = labelView;
+    }
+
+    void bind(final IntentOptionViewModel viewModel, final BottomSheetIntentListener listener) {
+        iconView.setImageDrawable(viewModel.getActivityIcon());
+        labelView.setText(viewModel.getLabel());
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                listener.onActivitySelected(viewModel.getIntent());
+            }
+        });
+    }
+}

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/IntentOptionViewModel.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/IntentOptionViewModel.java
@@ -1,0 +1,59 @@
+package com.alexstyl.specialdates.person;
+
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+
+public final class IntentOptionViewModel {
+
+    private final Drawable icon;
+    private final String label;
+    private final Intent intent;
+
+    IntentOptionViewModel(Drawable icon, String label, Intent intent) {
+        this.icon = icon;
+        this.label = label;
+        this.intent = intent;
+    }
+
+    Drawable getActivityIcon() {
+        return icon;
+    }
+
+    String getLabel() {
+        return label;
+    }
+
+    Intent getIntent() {
+        return intent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IntentOptionViewModel that = (IntentOptionViewModel) o;
+
+        if (!icon.equals(that.icon)) {
+            return false;
+        }
+        if (!label.equals(that.label)) {
+            return false;
+        }
+        return intent.equals(that.intent);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = icon.hashCode();
+        result = 31 * result + label.hashCode();
+        result = 31 * result + intent.hashCode();
+        return result;
+    }
+}
+

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/PersonActivity.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/PersonActivity.java
@@ -260,7 +260,10 @@ public class PersonActivity extends ThemedMementoActivity implements PersonView,
 
     @Override
     public void onActivitySelected(Intent intent) {
-        Log.d("TAG", "DONE!");
-        startActivity(intent);
+        try {
+            startActivity(intent);
+        } catch (ActivityNotFoundException ex) {
+            Toast.makeText(this, R.string.no_app_found, Toast.LENGTH_LONG).show();
+        }
     }
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/person/PersonDetailsNavigator.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/person/PersonDetailsNavigator.kt
@@ -1,0 +1,15 @@
+package com.alexstyl.specialdates.person
+
+
+import com.alexstyl.specialdates.ExternalNavigator
+import com.alexstyl.specialdates.Optional
+import com.alexstyl.specialdates.contact.Contact
+
+internal class PersonDetailsNavigator(private val navigator: ExternalNavigator) {
+
+    fun toViewContact(displayingContact: Optional<Contact>) {
+        if (displayingContact.isPresent) {
+            navigator.toContactDetails(displayingContact.get())
+        }
+    }
+}

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/ui/base/MementoActivity.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/ui/base/MementoActivity.kt
@@ -13,10 +13,6 @@ import com.alexstyl.android.Version
 
 open class MementoActivity : AppCompatActivity() {
 
-    /**
-     * Override this method in order to let the activity handle the up button.
-     * When pressed it will navigate the user to the parent of the activity
-     */
     private fun shouldUseHomeAsUp(): Boolean = parentActivityIntent != null
 
     override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsPresenter.kt
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/upcoming/UpcomingEventsPresenter.kt
@@ -13,7 +13,11 @@ internal class UpcomingEventsPresenter(private val firstDay: Date,
                                        private val workScheduler: Scheduler,
                                        private val resultScheduler: Scheduler) {
 
-    private val TRIGGER = 1
+
+    companion object {
+        private const val TRIGGER = 1
+    }
+
     private val subject = PublishSubject.create<Int>()
     private var disposable: Disposable? = null
 

--- a/android_mobile/src/main/res/layout/dialog_bottom_dialog.xml
+++ b/android_mobile/src/main/res/layout/dialog_bottom_dialog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="@dimen/bottom_sheet_layout_width"
+    android:layout_height="match_parent"
+    android:layout_gravity="center_horizontal"
+    android:orientation="vertical"
+    android:paddingBottom="24dp"
+    android:paddingLeft="24dp"
+    android:paddingRight="24dp"
+    android:paddingTop="16dp">
+
+    <TextView
+        android:id="@+id/bottom_sheet_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/add_event_pick_image_title"
+        android:textSize="16sp" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/bottom_sheet_grid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="16dp"
+        app:layoutManager="GridLayoutManager"
+        app:spanCount="4"
+        tools:listitem="@layout/row_image_option" />
+
+</LinearLayout>

--- a/android_mobile/src/main/res/menu/menu_person_details.xml
+++ b/android_mobile/src/main/res/menu/menu_person_details.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <item
+    android:id="@+id/menu_view_contact"
+    android:title="@string/View_contact"
+    app:showAsAction="never" />
+
+</menu>


### PR DESCRIPTION
#### Description

This PR adds the option to view the contact information from any other app, in case they want to edit the contact more in-depth. If the contact is a device contact then all the applications that support the action are queried. Otherwise if the contact is a friend from Facebook, the user is navigated to Facebook instead.

##### Test(s) added

nope. No new logic added

##### Screenshots

![profile](https://user-images.githubusercontent.com/1665273/35185569-c0996000-fdfe-11e7-967e-40919075a98c.png)
