### PR TITLE
Foreground wear

### DIFF
--- a/android_common/src/main/java/com/alexstyl/android/Version.java
+++ b/android_common/src/main/java/com/alexstyl/android/Version.java
@@ -41,4 +41,8 @@ public final class Version {
     static boolean hasMarshmallow() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
     }
+
+    public static boolean hasOreo() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+    }
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/dailyreminder/DailyReminderIntentService.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/dailyreminder/DailyReminderIntentService.java
@@ -128,7 +128,7 @@ public class DailyReminderIntentService extends IntentService {
     private void notifyForBankholidaysFor(Date date) {
         Optional<BankHoliday> bankHoliday = findBankholidayFor(date);
         if (bankHoliday.isPresent()) {
-            notifier.forBankholiday(date, bankHoliday.get());
+            notifier.forBankholiday(bankHoliday.get());
         }
     }
 

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/dailyreminder/DailyReminderNotifier.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/dailyreminder/DailyReminderNotifier.java
@@ -231,7 +231,7 @@ public final class DailyReminderNotifier {
 
     }
 
-    void forBankholiday(Date date, BankHoliday bankHoliday) {
+    void forBankholiday(BankHoliday bankHoliday) {
         PendingIntent intent = PendingIntent.getActivity(
                 context, NOTIFICATION_ID_DAILY_REMINDER_BANKHOLIDAYS,
                 UpcomingEventsActivity.getStartIntent(context),

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/wear/WearSyncPeopleEventsView.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/wear/WearSyncPeopleEventsView.java
@@ -2,7 +2,10 @@ package com.alexstyl.specialdates.wear;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 
+import com.alexstyl.android.Version;
 import com.alexstyl.specialdates.PeopleEventsView;
 
 public class WearSyncPeopleEventsView implements PeopleEventsView {
@@ -13,9 +16,14 @@ public class WearSyncPeopleEventsView implements PeopleEventsView {
         this.context = context;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     public void onEventsUpdated() {
         Intent service = new Intent(context, WearSyncService.class);
-        context.startService(service);
+        if (Version.hasOreo()) {
+            context.startForegroundService(service);
+        } else {
+            context.startService(service);
+        }
     }
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/wear/WearSyncService.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/wear/WearSyncService.java
@@ -1,12 +1,23 @@
 package com.alexstyl.specialdates.wear;
 
+import android.app.Activity;
 import android.app.IntentService;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 
+import com.alexstyl.android.Version;
 import com.alexstyl.specialdates.AppComponent;
 import com.alexstyl.specialdates.MementoApplication;
 import com.alexstyl.specialdates.Optional;
 import com.alexstyl.specialdates.contact.Contact;
+import com.alexstyl.specialdates.dailyreminder.DailyReminderNotifier;
 import com.alexstyl.specialdates.date.Date;
 import com.alexstyl.specialdates.events.namedays.NamedayUserSettings;
 import com.alexstyl.specialdates.events.peopleevents.ContactEventsOnADate;
@@ -18,13 +29,16 @@ import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
 import javax.inject.Inject;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class WearSyncService extends IntentService {
 
-    @Inject NamedayUserSettings namedayUserSettings;
-    @Inject PeopleEventsProvider peopleEventsProvider;
+    @Inject
+    NamedayUserSettings namedayUserSettings;
+    @Inject
+    PeopleEventsProvider peopleEventsProvider;
 
     public WearSyncService() {
         super(WearSyncService.class.getSimpleName());
@@ -33,8 +47,24 @@ public class WearSyncService extends IntentService {
     @Override
     public void onCreate() {
         super.onCreate();
-        AppComponent applicationModule = ((MementoApplication) getApplication()).getApplicationModule();
+        AppComponent applicationModule = ((MementoApplication) getApplication())
+                .getApplicationModule();
         applicationModule.inject(this);
+
+
+        if (Version.hasOreo()) {
+            initChannel();
+            Notification notification = new NotificationCompat
+                    .Builder(this, "Wear Service")
+                    .build();
+            startForeground(1, notification);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void initChannel() {
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        nm.createNotificationChannel(new NotificationChannel("Wear Service", "derp", NotificationManager.IMPORTANCE_DEFAULT));
     }
 
     @Override


### PR DESCRIPTION
#### Description

According to the latest changes in Android Oreo (8.1) apps cannot just start services from background. Because of that the `WearSyncService` needs to be called in the Foreground. This PR adds this behaviour.