### PR TITLE
Use max day in picker depending on month, year

### DIFF
--- a/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
@@ -11,7 +11,6 @@ import android.widget.NumberPicker;
 import com.alexstyl.specialdates.R;
 import com.alexstyl.specialdates.date.Date;
 import com.alexstyl.specialdates.date.MonthInt;
-import com.alexstyl.specialdates.date.Months;
 import com.alexstyl.specialdates.upcoming.MonthLabels;
 import com.novoda.notils.caster.Views;
 
@@ -20,7 +19,6 @@ import java.util.Locale;
 public class EventDatePicker extends LinearLayout {
 
     private static final int FIRST_DAY_OF_MONTH = 1;
-    private static final int LAST_DAY_OF_MONTH = 31;
 
     private final MonthLabels labels;
 
@@ -79,7 +77,7 @@ public class EventDatePicker extends LinearLayout {
 
     private void setupDayPicker() {
         dayPicker.setMinValue(FIRST_DAY_OF_MONTH);
-        dayPicker.setMaxValue(LAST_DAY_OF_MONTH);
+        dayPicker.setMaxValue(today.maxDaysInMonth());
 
         dayPicker.setValue(today.getDayOfMonth());
 
@@ -154,31 +152,15 @@ public class EventDatePicker extends LinearLayout {
 
     private final NumberPicker.OnValueChangeListener dateValidator = new NumberPicker.OnValueChangeListener() {
 
-        private static final int LAST_DAY_OF_FEBRUARY_LONG = 29;
-        private static final int LAST_DAY_OF_FEBRUARY_SHORT = 28;
-
         @Override
         public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
-            if (getMonth() == Months.FEBRUARY && isDisplayingYear()) {
-
-                if (isValidDate(LAST_DAY_OF_FEBRUARY_LONG, Months.FEBRUARY, getYear())) {
-                    dayPicker.setMaxValue(LAST_DAY_OF_FEBRUARY_LONG);
-                } else {
-                    dayPicker.setMaxValue(LAST_DAY_OF_FEBRUARY_SHORT);
-                }
+            if (isDisplayingYear()){
+                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth(), getYear()).maxDaysInMonth());
             } else {
-                dayPicker.setMaxValue(LAST_DAY_OF_MONTH);
+                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth()).maxDaysInMonth());
             }
         }
 
-        private boolean isValidDate(int dayOfMonth, int month, int year) {
-            try {
-                Date.Companion.on(dayOfMonth, month, year);
-                return true;
-            } catch (IllegalArgumentException ex) {
-                return false;
-            }
-        }
     };
 
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
@@ -61,6 +61,7 @@ public class EventDatePicker extends LinearLayout {
                 } else {
                     hideYearPicker();
                 }
+                updateMaximumDaysInCurrentMonth();
             }
 
             private void hideYearPicker() {
@@ -77,7 +78,7 @@ public class EventDatePicker extends LinearLayout {
 
     private void setupDayPicker() {
         dayPicker.setMinValue(FIRST_DAY_OF_MONTH);
-        dayPicker.setMaxValue(today.daysInCurrentMonth());
+        dayPicker.setMaxValue(today.getDaysInCurrentMonth());
 
         dayPicker.setValue(today.getDayOfMonth());
 
@@ -95,13 +96,13 @@ public class EventDatePicker extends LinearLayout {
 
     private void setupYearPicker() {
         yearPicker.setMinValue(FIRST_YEAR);
-        yearPicker.setMaxValue(todaysYear());
+        yearPicker.setMaxValue(currentYear());
 
-        yearPicker.setValue(todaysYear());
+        yearPicker.setValue(currentYear());
         yearPicker.setOnValueChangedListener(dateValidator);
     }
 
-    private Integer todaysYear() {
+    private Integer currentYear() {
         return today.getYear();
     }
 
@@ -115,7 +116,7 @@ public class EventDatePicker extends LinearLayout {
         } else {
             dayPicker.setValue(dateToDisplay.getDayOfMonth());
             monthPicker.setValue(dateToDisplay.getMonth());
-            yearPicker.setValue(todaysYear());
+            yearPicker.setValue(currentYear());
             yearPicker.setVisibility(GONE);
             includesYearCheckbox.setChecked(false);
         }
@@ -154,13 +155,20 @@ public class EventDatePicker extends LinearLayout {
 
         @Override
         public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
-            if (isDisplayingYear()){
-                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth(), getYear()).daysInCurrentMonth());
-            } else {
-                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth()).daysInCurrentMonth());
-            }
+            updateMaximumDaysInCurrentMonth();
         }
 
     };
+
+    private void updateMaximumDaysInCurrentMonth() {
+        int maxDays;
+        if (isDisplayingYear()){
+            maxDays = Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth(), getYear()).getDaysInCurrentMonth();
+        } else {
+            maxDays = Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth()).getDaysInCurrentMonth();
+        }
+
+        dayPicker.setMaxValue(maxDays);
+    }
 
 }

--- a/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
+++ b/android_mobile/src/main/java/com/alexstyl/specialdates/addevent/ui/EventDatePicker.java
@@ -77,7 +77,7 @@ public class EventDatePicker extends LinearLayout {
 
     private void setupDayPicker() {
         dayPicker.setMinValue(FIRST_DAY_OF_MONTH);
-        dayPicker.setMaxValue(today.maxDaysInMonth());
+        dayPicker.setMaxValue(today.daysInCurrentMonth());
 
         dayPicker.setValue(today.getDayOfMonth());
 
@@ -155,9 +155,9 @@ public class EventDatePicker extends LinearLayout {
         @Override
         public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
             if (isDisplayingYear()){
-                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth(), getYear()).maxDaysInMonth());
+                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth(), getYear()).daysInCurrentMonth());
             } else {
-                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth()).maxDaysInMonth());
+                dayPicker.setMaxValue(Date.Companion.on(FIRST_DAY_OF_MONTH, getMonth()).daysInCurrentMonth());
             }
         }
 

--- a/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
+++ b/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
@@ -42,7 +42,8 @@ data class Date(private val localDate: LocalDate, private val yearOptional: Opti
 
     fun hasNoYear(): Boolean = !yearOptional.isPresent
 
-    fun daysInCurrentMonth(): Int = localDate.dayOfMonth().maximumValue
+    val daysInCurrentMonth: Int
+            get() = localDate.dayOfMonth().maximumValue
 
     override fun compareTo(other: Date): Int {
         if (this.hasYear() && other.hasYear()) {

--- a/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
+++ b/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
@@ -42,15 +42,7 @@ data class Date(private val localDate: LocalDate, private val yearOptional: Opti
 
     fun hasNoYear(): Boolean = !yearOptional.isPresent
 
-    fun maxDaysInMonth(): Int {
-        if (month == Months.FEBRUARY && hasNoYear()) {
-            // Yoda time returns max 29 for February when no year provided,
-            // it is more common to have 28 days in date picker
-            return 28
-        }
-
-        return localDate.dayOfMonth().maximumValue
-    }
+    fun daysInCurrentMonth(): Int = localDate.dayOfMonth().maximumValue
 
     override fun compareTo(other: Date): Int {
         if (this.hasYear() && other.hasYear()) {

--- a/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
+++ b/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
@@ -42,6 +42,16 @@ data class Date(private val localDate: LocalDate, private val yearOptional: Opti
 
     fun hasNoYear(): Boolean = !yearOptional.isPresent
 
+    fun maxDaysInMonth(): Int {
+        if (month == Months.FEBRUARY && hasNoYear()) {
+            // Yoda time returns max 29 for February when no year provided,
+            // it is more common to have 28 days in date picker
+            return 28
+        }
+
+        return localDate.dayOfMonth().maximumValue
+    }
+
     override fun compareTo(other: Date): Int {
         if (this.hasYear() && other.hasYear()) {
             val yearOne = this.year
@@ -75,7 +85,7 @@ data class Date(private val localDate: LocalDate, private val yearOptional: Opti
 
         fun on(dayOfMonth: Int, @MonthInt month: Int): Date {
             val localDate = LocalDate(Months.NO_YEAR, month, dayOfMonth)
-            return Date(localDate, Optional.absent<Int>())
+            return Date(localDate, Optional.absent())
         }
 
         fun on(dayOfMonth: Int, @MonthInt month: Int, year: Int): Date {

--- a/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
+++ b/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
@@ -30,7 +30,7 @@ public class DateTest {
     }
 
     @Test
-    public void givenAEndOfTheYearDate_whenAddingOneDay_thenTheFirstDayOftheNextYearIsReturned() {
+    public void givenAEndOfTheYearDate_whenAddingOneDay_thenTheFirstDayOfTheNextYearIsReturned() {
         Date lastDayOfYear = Date.Companion.on(31, DECEMBER, 1990);
         Date firstDayOfNextYear = lastDayOfYear.addDay(1);
 
@@ -38,6 +38,41 @@ public class DateTest {
         assertThat(firstDayOfNextYear.getDayOfMonth()).isEqualTo(1);
         int nextYear = lastDayOfYear.getYear() + 1;
         assertThat(firstDayOfNextYear.getYear()).isEqualTo(nextYear);
+    }
+
+    @Test
+    public void testMaxJanuaryDate() {
+        Date date = Date.Companion.on(1, JANUARY);
+
+        assertThat(date.maxDaysInMonth()).isEqualTo(31);
+    }
+
+    @Test
+    public void testMaxFebruaryDateNoYear() {
+        Date date = Date.Companion.on(1, FEBRUARY);
+
+        assertThat(date.maxDaysInMonth()).isEqualTo(28);
+    }
+
+    @Test
+    public void testMaxFebruaryDateCommonYear() {
+        Date date = Date.Companion.on(1, FEBRUARY, 2018);
+
+        assertThat(date.maxDaysInMonth()).isEqualTo(28);
+    }
+
+    @Test
+    public void testMaxFebruaryDateInLeapYear() {
+        Date date = Date.Companion.on(1, FEBRUARY, 2020);
+
+        assertThat(date.maxDaysInMonth()).isEqualTo(29);
+    }
+
+    @Test
+    public void testMaxAprilDate() {
+        Date date = Date.Companion.on(1, APRIL);
+
+        assertThat(date.maxDaysInMonth()).isEqualTo(30);
     }
 
     @Test

--- a/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
+++ b/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
@@ -41,24 +41,24 @@ public class DateTest {
     }
 
     @Test
-    public void givenDateWithShortMonth_thenReturn29Days() {
+    public void givenDateWithShortMonthAndNoYearSpecified_thenReturn29Days() {
         Date date = Date.Companion.on(1, FEBRUARY);
 
-        assertThat(date.daysInCurrentMonth()).isEqualTo(29);
+        assertThat(date.getDaysInCurrentMonth()).isEqualTo(29);
     }
 
     @Test
     public void givenDateWithShortMonthAndCommonYear_thenReturn28Days() {
         Date date = Date.Companion.on(1, FEBRUARY, 2018);
 
-        assertThat(date.daysInCurrentMonth()).isEqualTo(28);
+        assertThat(date.getDaysInCurrentMonth()).isEqualTo(28);
     }
 
     @Test
     public void givenDateWithShortMonthAndLeapYear_thenReturn29Days() {
         Date date = Date.Companion.on(1, FEBRUARY, 2020);
 
-        assertThat(date.daysInCurrentMonth()).isEqualTo(29);
+        assertThat(date.getDaysInCurrentMonth()).isEqualTo(29);
     }
 
     @Test

--- a/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
+++ b/memento/src/test/java/com/alexstyl/specialdates/events/DateTest.java
@@ -41,38 +41,24 @@ public class DateTest {
     }
 
     @Test
-    public void testMaxJanuaryDate() {
-        Date date = Date.Companion.on(1, JANUARY);
-
-        assertThat(date.maxDaysInMonth()).isEqualTo(31);
-    }
-
-    @Test
-    public void testMaxFebruaryDateNoYear() {
+    public void givenDateWithShortMonth_thenReturn29Days() {
         Date date = Date.Companion.on(1, FEBRUARY);
 
-        assertThat(date.maxDaysInMonth()).isEqualTo(28);
+        assertThat(date.daysInCurrentMonth()).isEqualTo(29);
     }
 
     @Test
-    public void testMaxFebruaryDateCommonYear() {
+    public void givenDateWithShortMonthAndCommonYear_thenReturn28Days() {
         Date date = Date.Companion.on(1, FEBRUARY, 2018);
 
-        assertThat(date.maxDaysInMonth()).isEqualTo(28);
+        assertThat(date.daysInCurrentMonth()).isEqualTo(28);
     }
 
     @Test
-    public void testMaxFebruaryDateInLeapYear() {
+    public void givenDateWithShortMonthAndLeapYear_thenReturn29Days() {
         Date date = Date.Companion.on(1, FEBRUARY, 2020);
 
-        assertThat(date.maxDaysInMonth()).isEqualTo(29);
-    }
-
-    @Test
-    public void testMaxAprilDate() {
-        Date date = Date.Companion.on(1, APRIL);
-
-        assertThat(date.maxDaysInMonth()).isEqualTo(30);
+        assertThat(date.daysInCurrentMonth()).isEqualTo(29);
     }
 
     @Test


### PR DESCRIPTION
- Use JodaDate to calculate the accepted values that will shown on the EventDatePicker.
- Override logic of Joda when the year is not present for February so as to keep existing functionality.

Resolve issue #169

#### Description

The date picker was crashing when it is started a month with 31 days (ie. May).
Then you select at day the 31st and then switch to previous month that has 30 days (ie. April)
Pressing ok will cause a crash.

Same problem was repoducible with February that has 28 days.


##### Test(s) added

 Yes
