### PR TITLE
Bug in generating the label for birthdays

### DIFF
--- a/memento/src/main/java/com/alexstyl/specialdates/date/ContactEvent.kt
+++ b/memento/src/main/java/com/alexstyl/specialdates/date/ContactEvent.kt
@@ -9,16 +9,22 @@ import com.alexstyl.specialdates.events.peopleevents.StandardEventType
 data class ContactEvent(val deviceEventId: Optional<Long>, val type: EventType, val date: Date, val contact: Contact) {
 
     fun getLabel(dateWithYear: Date, strings: Strings): String {
-        if (type === StandardEventType.BIRTHDAY) {
-            if (date.hasYear()) {
-
-                val age = dateWithYear.year!! - date.year!!
-                if (age > 0) {
-                    return strings.turnsAge(age)
+        if (type === StandardEventType.BIRTHDAY && date.hasYear()) {
+            val age = (dateWithYear.year!! - date.year!!).let {
+                if (birthdayIsBeforeDateIgnoringYear(dateWithYear)) {
+                    it + 1
+                } else {
+                    it
                 }
+            }
+
+            if (age > 0) {
+                return strings.turnsAge(age)
             }
         }
         return type.getEventName(strings)
     }
 
+    private fun birthdayIsBeforeDateIgnoringYear(dateWithYear: Date) =
+        dateWithYear.withoutYear() > date.withoutYear()
 }

--- a/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
+++ b/memento/src/main/java/com/alexstyl/specialdates/date/Date.kt
@@ -44,6 +44,8 @@ data class Date(private val localDate: LocalDate, val year: Int?) : Comparable<D
         return localDate.compareTo(other.localDate)
     }
 
+    fun withoutYear() = dateOn(localDate.dayOfMonth, localDate.monthOfYear, null)
+
 
     companion object {
 

--- a/memento/src/test/java/com/alexstyl/specialdates/date/ContactEventTest.kt
+++ b/memento/src/test/java/com/alexstyl/specialdates/date/ContactEventTest.kt
@@ -3,7 +3,9 @@ package com.alexstyl.specialdates.date
 import com.alexstyl.specialdates.JavaStrings
 import com.alexstyl.specialdates.Optional
 import com.alexstyl.specialdates.contact.ContactFixture
+import com.alexstyl.specialdates.date.Months.AUGUST
 import com.alexstyl.specialdates.date.Months.JANUARY
+import com.alexstyl.specialdates.date.Months.SEPTEMBER
 import com.alexstyl.specialdates.events.peopleevents.StandardEventType
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
@@ -54,6 +56,22 @@ class ContactEventTest {
         val contactEvent = ContactEvent(NO_DEVICE_ID, StandardEventType.BIRTHDAY, eventDate, ANY_CONTACT)
         val label = contactEvent.getLabel(dateOn(1, JANUARY, todaysDate().year), strings)
         assertThat(label).isEqualTo("Turns 10")
+    }
+
+    @Test
+    fun labelAfterBirthdayInCurrentYear() {
+        val contactEvent = ContactEvent(
+            NO_DEVICE_ID,
+            StandardEventType.BIRTHDAY,
+            dateOn(21, AUGUST, 1988),
+            ANY_CONTACT
+        )
+
+        val today = dateOn(1, SEPTEMBER, 2018)
+
+        val label = contactEvent.getLabel(today, strings)
+
+        assertThat(label).isEqualTo("Turns 31")
     }
 
     companion object {


### PR DESCRIPTION
#### Description

When generating the label for a birthday, given the current day was past that birthday (see test for example), the date was missing one year.

##### Test(s) added

Yep